### PR TITLE
Checksum Cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,6 @@ itest_clean:
 itest: compile itest_bundler itest_create itest_run itest_clean
 
 itest_run:
-	cd itest;erlc -pz ../deps/chef_objects/ebin *.erl
-	@erl -pa deps/*/ebin -pa ebin -pa itest -noshell -eval "eunit:test(itest, [verbose])" \
+	cd itest;erlc -I ../include -pz ../deps/chef_objects/ebin *.erl
+	@erl -I include -pa deps/*/ebin -pa ebin -pa itest -noshell -eval "eunit:test(itest, [verbose])" \
 	-s erlang halt -db_type $(DB_TYPE)

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ itest_clean:
 	@rm -f itest/*.beam
 	@echo Dropping integration test database
 	@cd itest;bundle exec ./create_schema.rb ${DB_TYPE} destroy
+	@rm -rf itest/Gemfile.lock
 
 itest: compile itest_bundler itest_create itest_run itest_clean
 

--- a/include/chef_db.hrl
+++ b/include/chef_db.hrl
@@ -1,0 +1,21 @@
+%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-record(chef_db_cb_version_delete, {
+          'cookbook_delete' :: boolean(),
+          'deleted_checksums' :: [ Checksum::binary()]
+         }).

--- a/itest/helper_mysql_statements.config
+++ b/itest/helper_mysql_statements.config
@@ -1,0 +1,3 @@
+
+{find_checksum_by_id,
+  <<"SELECT checksum FROM checksums WHERE org_id = ? AND checksum = ?">>}.

--- a/itest/helper_pgsql_statements.config
+++ b/itest/helper_pgsql_statements.config
@@ -1,0 +1,3 @@
+
+{find_checksum_by_id,
+  <<"SELECT checksum FROM checksums WHERE org_id = $1 AND checksum = $2">>}.

--- a/itest/itest.erl
+++ b/itest/itest.erl
@@ -1603,7 +1603,7 @@ delete_cookbook_version_checksums() ->
                                             CookbookVersion#chef_cookbook_version.minor,
                                             CookbookVersion#chef_cookbook_version.patch}}),
 
-    % Verify all checksums exist
+    %% Verify all checksums exist
     [Checksum1, Checksum2] = Got#chef_cookbook_version.checksums,
     ?assertEqual(true, checksum_exists(Got#chef_cookbook_version.org_id, Checksum1)),
     ?assertEqual(true, checksum_exists(Got#chef_cookbook_version.org_id, Checksum2)),

--- a/itest/itest.erl
+++ b/itest/itest.erl
@@ -1601,8 +1601,8 @@ delete_cookbook_version_checksums() ->
 
     % Verify all checksums exist
     [Checksum1, Checksum2] = Got#chef_cookbook_version.checksums,
-    ?assertEqual(true, chef_sql:checksum_exists(Checksum1)),
-    ?assertEqual(true, chef_sql:checksum_exists(Checksum2)),
+    ?assertEqual(true, chef_sql:checksum_exists(Got#chef_cookbook_version.org_id, Checksum1)),
+    ?assertEqual(true, chef_sql:checksum_exists(Got#chef_cookbook_version.org_id, Checksum2)),
 
     %% We should have gotten back a list of deleted checksums
     {ok, N, DeletedChecksums} = chef_sql:delete_cookbook_version(Got),
@@ -1618,8 +1618,8 @@ delete_cookbook_version_checksums() ->
                                                               Got#chef_cookbook_version.patch}})),
 
     %% Ensure the checksums don't exist in the checksum table
-    ?assertEqual(false, chef_sql:checksum_exists(Checksum1)),
-    ?assertEqual(false, chef_sql:checksum_exists(Checksum2)).
+    ?assertEqual(false, chef_sql:checksum_exists(Got#chef_cookbook_version.org_id, Checksum1)),
+    ?assertEqual(false, chef_sql:checksum_exists(Got#chef_cookbook_version.org_id, Checksum2)).
 
 %% @doc check that the cookbook row is still in the database until all
 %% versions of the cookbook have been deleted

--- a/priv/mysql_statements.config
+++ b/priv/mysql_statements.config
@@ -375,6 +375,9 @@
   <<"INSERT INTO checksums(org_id, checksum)
      VALUES (?, ?)">>}.
 
+{delete_checksum_by_id,
+  <<"DELETE FROM checksums where checksum = ?">>}.
+
 {insert_sandboxed_checksum,
  <<"INSERT INTO sandboxed_checksums(org_id, sandbox_id, checksum, created_at)
     VALUES (?, ?, ?, ?)">>}.

--- a/priv/mysql_statements.config
+++ b/priv/mysql_statements.config
@@ -368,6 +368,9 @@
 {delete_sandbox_by_id,
  <<"DELETE FROM sandboxed_checksums WHERE sandbox_id = ?">>}.
 
+{find_checksum_by_id,
+  <<"SELECT checksum FROM checksums WHERE checksum = ?">>}.
+
 {insert_checksum,
   <<"INSERT INTO checksums(org_id, checksum)
      VALUES (?, ?)">>}.

--- a/priv/mysql_statements.config
+++ b/priv/mysql_statements.config
@@ -369,14 +369,14 @@
  <<"DELETE FROM sandboxed_checksums WHERE sandbox_id = ?">>}.
 
 {find_checksum_by_id,
-  <<"SELECT checksum FROM checksums WHERE checksum = ?">>}.
+  <<"SELECT checksum FROM checksums WHERE org_id = ? AND checksum = ?">>}.
 
 {insert_checksum,
   <<"INSERT INTO checksums(org_id, checksum)
      VALUES (?, ?)">>}.
 
 {delete_checksum_by_id,
-  <<"DELETE FROM checksums where checksum = ?">>}.
+  <<"DELETE FROM checksums where org_id = ? AND checksum = ?">>}.
 
 {insert_sandboxed_checksum,
  <<"INSERT INTO sandboxed_checksums(org_id, sandbox_id, checksum, created_at)

--- a/priv/mysql_statements.config
+++ b/priv/mysql_statements.config
@@ -368,9 +368,6 @@
 {delete_sandbox_by_id,
  <<"DELETE FROM sandboxed_checksums WHERE sandbox_id = ?">>}.
 
-{find_checksum_by_id,
-  <<"SELECT checksum FROM checksums WHERE org_id = ? AND checksum = ?">>}.
-
 {insert_checksum,
   <<"INSERT INTO checksums(org_id, checksum)
      VALUES (?, ?)">>}.

--- a/priv/pgsql_statements.config
+++ b/priv/pgsql_statements.config
@@ -374,14 +374,14 @@
  <<"DELETE FROM sandboxed_checksums WHERE sandbox_id = $1">>}.
 
 {find_checksum_by_id,
-  <<"SELECT checksum FROM checksums WHERE checksum = $1">>}.
+  <<"SELECT checksum FROM checksums WHERE org_id = $1 AND checksum = $2">>}.
 
 {insert_checksum,
   <<"INSERT INTO checksums(org_id, checksum)
      VALUES ($1, $2)">>}.
 
 {delete_checksum_by_id,
-  <<"DELETE FROM checksums where checksum = $1">>}.
+  <<"DELETE FROM checksums where org_id = $1 AND checksum = $2">>}.
 
 {insert_sandboxed_checksum,
  <<"INSERT INTO sandboxed_checksums(org_id, sandbox_id, checksum, created_at)

--- a/priv/pgsql_statements.config
+++ b/priv/pgsql_statements.config
@@ -373,9 +373,6 @@
 {delete_sandbox_by_id,
  <<"DELETE FROM sandboxed_checksums WHERE sandbox_id = $1">>}.
 
-{find_checksum_by_id,
-  <<"SELECT checksum FROM checksums WHERE org_id = $1 AND checksum = $2">>}.
-
 {insert_checksum,
   <<"INSERT INTO checksums(org_id, checksum)
      VALUES ($1, $2)">>}.

--- a/priv/pgsql_statements.config
+++ b/priv/pgsql_statements.config
@@ -373,6 +373,9 @@
 {delete_sandbox_by_id,
  <<"DELETE FROM sandboxed_checksums WHERE sandbox_id = $1">>}.
 
+{find_checksum_by_id,
+  <<"SELECT checksum FROM checksums WHERE checksum = $1">>}.
+
 {insert_checksum,
   <<"INSERT INTO checksums(org_id, checksum)
      VALUES ($1, $2)">>}.

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -5,6 +5,7 @@
 %% @author Mark Anderson <mark@opscode.com>
 %% @author Christopher Maier <cm@opscode.com>
 %% @author Mark Mzyk <mmzyk@opscode.com>
+%% @author Seth Chisamore <schisamo@opscode.com>
 %% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
@@ -745,7 +746,13 @@ update_cookbook_version(#context{}=Ctx, UpdatedCookbookVersion, ActorId) ->
                               CookbookVersion::#chef_cookbook_version{})
    -> {ok, 1 | 2} | not_found | {error, _}.
 delete_cookbook_version(#context{}=Ctx, #chef_cookbook_version{}=CookbookVersion) ->
-    delete_object(Ctx, delete_cookbook_version, CookbookVersion).
+    case delete_object(Ctx, delete_cookbook_version, CookbookVersion) of
+        {ok, N, _DeletedChecksums} ->
+            %% TODO - some awesome parallel s3 deletion action
+            {ok, N};
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 -spec delete_node(#context{}, #chef_node{}) -> {ok, 1 | 2} | not_found | {error, _}.
 %% @doc Delete a node. You can provide either a `#chef_node{}' record or just the ID of the

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -746,12 +746,11 @@ update_cookbook_version(#context{}=Ctx, UpdatedCookbookVersion, ActorId) ->
 -spec delete_cookbook_version(Ctx :: #context{},
                               CookbookVersion :: #chef_cookbook_version{}) ->
                                 {ok, 1 | 2} | not_found | {error, term()}.
-delete_cookbook_version(#context{}=Ctx, #chef_cookbook_version{org_id=_OrgId}=CookbookVersion) ->
+delete_cookbook_version(#context{}=Ctx, #chef_cookbook_version{org_id=OrgId}=CookbookVersion) ->
     case delete_object(Ctx, delete_cookbook_version, CookbookVersion) of
-        #chef_db_cb_version_delete{cookbook_delete=CookbookDeleted, deleted_checksums=_DeletedChecksums} ->
-            %% TODO - some awesome parallel s3 deletion action
-            % chef_s3:delete_checksums(OrgId, DeletedChecksums),
-            %% FIXME: return the actual chef_db_cb_version_delete record to the caller
+        #chef_db_cb_version_delete{cookbook_delete=CookbookDeleted, deleted_checksums=DeletedChecksums} ->
+            chef_s3:delete_checksums(OrgId, DeletedChecksums),
+            %% TODO: return the actual chef_db_cb_version_delete record to the caller
             case CookbookDeleted of
                 false -> {ok, 1};
                 true -> {ok, 2}

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -1190,6 +1190,15 @@ fetch_couchdb_data_bags(#context{reqid = ReqId, otto_connection = S}, {id, OrgId
                                                             {error, _}.
 %% @doc Delete a object. You can provide either a `#chef_object{}' record or just the ID of
 %% the object.
+
+%% SPECIAL CASE - We need an OrgId and Name in addition to the Id when deleting
+%% cookbook versions.
+delete_object(#context{reqid = ReqId}, Fun, #chef_cookbook_version{} = CookbookVersion) ->
+    case stats_hero:ctime(ReqId, stats_hero:label(chef_sql, Fun),
+                          fun() -> chef_sql:Fun(CookbookVersion) end) of
+        {ok, not_found} -> not_found;
+        Result -> Result
+    end;
 delete_object(#context{}=Ctx, Fun, Object) when is_tuple(Object) ->
     delete_object(Ctx, Fun, get_id(Object));
 delete_object(#context{reqid = ReqId}, Fun, Id) ->
@@ -1308,6 +1317,4 @@ get_id(#chef_data_bag{id = Id}) ->
 get_id(#chef_data_bag_item{id = Id}) ->
     Id;
 get_id(#chef_sandbox{id = Id}) ->
-    Id;
-get_id(#chef_cookbook_version{id = Id}) ->
     Id.

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -1190,21 +1190,13 @@ fetch_couchdb_data_bags(#context{reqid = ReqId, otto_connection = S}, {id, OrgId
                                                             {error, _}.
 %% @doc Delete a object. You can provide either a `#chef_object{}' record or just the ID of
 %% the object.
-delete_object(#context{reqid = ReqId}, Fun, #chef_cookbook_version{} = CookbookVersion) ->
-    case stats_hero:ctime(ReqId, stats_hero:label(chef_sql, Fun),
-                          fun() -> chef_sql:Fun(CookbookVersion) end) of
-        {ok, not_found} -> not_found;
-        {ok, N} -> {ok, N};
-        {error, Error} -> {error, Error}
-    end;
 delete_object(#context{}=Ctx, Fun, Object) when is_tuple(Object) ->
     delete_object(Ctx, Fun, get_id(Object));
 delete_object(#context{reqid = ReqId}, Fun, Id) ->
     case stats_hero:ctime(ReqId, stats_hero:label(chef_sql, Fun),
                           fun() -> chef_sql:Fun(Id) end) of
         {ok, not_found} -> not_found;
-        {ok, N} -> {ok, N};
-        {error, Error} -> {error, Error}
+        Result -> Result
     end.
 
 -spec update_object(#context{}, object_id(), update_fun(), chef_object() | #chef_cookbook_version{}) -> ok |

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -122,6 +122,7 @@
          new_data_bag_record/4,
          new_data_bag_item_record/5]).
 
+-include_lib("chef_db/include/chef_db.hrl").
 -include_lib("chef_objects/include/chef_types.hrl").
 -include_lib("stats_hero/include/stats_hero.hrl").
 
@@ -745,13 +746,17 @@ update_cookbook_version(#context{}=Ctx, UpdatedCookbookVersion, ActorId) ->
 -spec delete_cookbook_version(Ctx::#context{},
                               CookbookVersion::#chef_cookbook_version{})
    -> {ok, 1 | 2} | not_found | {error, _}.
-delete_cookbook_version(#context{}=Ctx, #chef_cookbook_version{}=CookbookVersion) ->
+delete_cookbook_version(#context{}=Ctx, #chef_cookbook_version{org_id=_OrgId}=CookbookVersion) ->
     case delete_object(Ctx, delete_cookbook_version, CookbookVersion) of
-        {ok, N, _DeletedChecksums} ->
+        #chef_db_cb_version_delete{cookbook_delete=CookbookDeleted, deleted_checksums=_DeletedChecksums} ->
             %% TODO - some awesome parallel s3 deletion action
-            {ok, N};
-        {error, Reason} ->
-            {error, Reason}
+            % chef_s3:delete_checksums(OrgId, DeletedChecksums),
+            %% FIXME: return the actual chef_db_cb_version_delete record to the caller
+            case CookbookDeleted of
+                false -> {ok, 1};
+                true -> {ok, 2}
+            end;
+        Result -> Result %% not_found or {error, _}
     end.
 
 -spec delete_node(#context{}, #chef_node{}) -> {ok, 1 | 2} | not_found | {error, _}.

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -743,9 +743,9 @@ update_cookbook_version(#context{}=Ctx, UpdatedCookbookVersion, ActorId) ->
     update_object(Ctx, ActorId, update_cookbook_version, UpdatedCookbookVersion).
 
 %% @doc Delete a cookbook version
--spec delete_cookbook_version(Ctx::#context{},
-                              CookbookVersion::#chef_cookbook_version{})
-   -> {ok, 1 | 2} | not_found | {error, _}.
+-spec delete_cookbook_version(Ctx :: #context{},
+                              CookbookVersion :: #chef_cookbook_version{}) ->
+                                {ok, 1 | 2} | not_found | {error, term()}.
 delete_cookbook_version(#context{}=Ctx, #chef_cookbook_version{org_id=_OrgId}=CookbookVersion) ->
     case delete_object(Ctx, delete_cookbook_version, CookbookVersion) of
         #chef_db_cb_version_delete{cookbook_delete=CookbookDeleted, deleted_checksums=_DeletedChecksums} ->
@@ -1187,6 +1187,7 @@ fetch_couchdb_data_bags(#context{reqid = ReqId, otto_connection = S}, {id, OrgId
                     Object :: chef_object() | object_id() | #chef_client{} | #chef_sandbox{} |
                               #chef_cookbook_version{} ) -> {ok, 1 | 2} |
                                                             not_found |
+                                                            #chef_db_cb_version_delete{} |
                                                             {error, _}.
 %% @doc Delete a object. You can provide either a `#chef_object{}' record or just the ID of
 %% the object.
@@ -1308,4 +1309,6 @@ get_id(#chef_data_bag{id = Id}) ->
 get_id(#chef_data_bag_item{id = Id}) ->
     Id;
 get_id(#chef_sandbox{id = Id}) ->
+    Id;
+get_id(#chef_cookbook_version{id = Id}) ->
     Id.

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -1326,8 +1326,9 @@ fetch_cookbook_authz(OrgId, CookbookName) ->
     end.
 
 %% @doc Delete all checksums for a given cookbook version
--spec delete_cookbook_version_checksums(OrgId::binary(),
-                       CookbookVersionId::binary()) -> {ok, 1 } | {error, _}.
+-spec delete_cookbook_version_checksums(OrgId::object_id(),
+                                       CookbookVersionId::object_id()) ->
+                                        {ok, [binary()]} | {error, term()}.
 delete_cookbook_version_checksums(OrgId, CookbookVersionId) ->
     % retrieve a list of checksums before we delete the
     % cookbook_version_checksums record
@@ -1344,7 +1345,7 @@ delete_cookbook_version_checksums(OrgId, CookbookVersionId) ->
 %% another cookbook_version_checksum record.  Returns a list of deleted checksum
 %% ids for further upstream processing(ie delete the checksums from S3).
 -spec delete_checksums(OrgId::binary(),
-                       Checksums::[binary()]) -> {ok, [binary()] } | {error, _}.
+                       Checksums::[binary()]) -> [binary()].
 delete_checksums(OrgId, Checksums) ->
     lists:foldl(fun(Checksum, Acc) ->
             case sqerl:statement(delete_checksum_by_id, [OrgId, Checksum]) of

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -34,7 +34,6 @@
 
 -export([fetch_user/1,
          %% checksum ops
-         checksum_exists/2,
          mark_checksums_as_uploaded/2,
          non_uploaded_checksums/2,
 
@@ -891,19 +890,6 @@ delete_sandbox(SandboxId) when is_binary(SandboxId) ->
     delete_object(delete_sandbox_by_id, SandboxId).
 
 %% Checksum Operations
-
-%% @doc Helper function for testing checksum existence.
--spec checksum_exists(OrgId :: binary(), ChecksumId :: binary()) ->
-                             boolean() | {error, term()}.
-checksum_exists(OrgId, ChecksumId) ->
-    case sqerl:select(find_checksum_by_id, [OrgId, ChecksumId], first_as_scalar, [checksum]) of
-        {ok, Checksum} when is_binary(Checksum) ->
-            true;
-        {ok, none} ->
-            false;
-        {error, Reason} ->
-            {error, Reason}
-    end.
 
 %% @doc Given an Org and list of checksums, mark all of them as having been uploaded.  In
 %% practice, this means adding a new row to the checksums table. Returns 'ok' if all are

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -1356,11 +1356,10 @@ delete_checksums(OrgId, Checksums) ->
                     %% The checksum may still be associated with
                     %% another cookbook version record which is OK!
                     Acc;
-                {error, Error} ->
-                    error_logger:error_msg("The following error occured
-                                          when trying to delete checksum
-                                          record ~p for organization ~p: ~p~n",
-                                          [Checksum, OrgId, Error]),
+                {error, Reason} ->
+                    error_logger:error_msg("Checksum deletion error: ~p~n"
+                                           "{~p,delete_checksums,2,[{file,~p},{line,~p}]}~n",
+                                           [Reason, ?MODULE, ?FILE, ?LINE]),
                     Acc
             end
       end,

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -1344,15 +1344,11 @@ delete_cookbook_version_checksums(OrgId, CookbookVersionId) ->
     Checksums = fetch_cookbook_version_checksums(OrgId, CookbookVersionId),
     case sqerl:statement(delete_cookbook_checksums_by_orgid_cookbook_versionid,
                             [OrgId, CookbookVersionId]) of
-        {ok, N} when is_integer(N) -> %% pretend there is 1
-            delete_checksums(OrgId, Checksums);
-        {ok, none} ->
-            %% this is ok, there might be no checksums to delete
+        {ok, _} ->
             delete_checksums(OrgId, Checksums);
         {error, Error} ->
             {error, Error}
     end.
-
 %% @doc Deletes a list of checksums from the checksums table.  Happily swallows
 %% foreign_key constraint errors assuming the checksum is still associated with
 %% another cookbook_version_checksum record.  Returns a list of deleted checksum

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -1374,7 +1374,7 @@ delete_checksums(OrgId, Checksums) ->
                       end,
                       [],
                       Checksums),
-    {ok, lists:reverse(DeletedChecksums)}.
+    {ok, DeletedChecksums}.
 
 %% @doc try and delete the row from cookbooks table.  It is protected by a
 %% ON DELETE RESTRICT from cookbook_versions so we get a FK violation if there

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -1350,7 +1350,11 @@ delete_checksums(OrgId, Checksums) ->
                                     %% The checksum may still be associated with
                                     %% another cookbook version record which is OK!
                                     Acc;
-                                {error, _Error} ->
+                                {error, Error} ->
+                                    error_logger:error_msg("The following error occured
+                                                          when trying to delete checksum
+                                                          record ~p for organization ~p: ~p~n",
+                                                          [Checksum, OrgId, Error]),
                                     Acc
                             end
                       end,

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -834,7 +834,7 @@ update_cookbook_version_checksums(#chef_cookbook_version{ id        = Id,
 delete_cookbook_version(#chef_cookbook_version{id=CookbookVersionId,
                                                org_id=OrgId,
                                                name=Name}) ->
-    case delete_checksums(OrgId, CookbookVersionId) of
+    case delete_cookbook_version_checksums(OrgId, CookbookVersionId) of
         {ok, DeletedChecksums} ->
             case delete_object(delete_cookbook_version_by_id, CookbookVersionId) of
                 {ok, 1} ->
@@ -1336,9 +1336,9 @@ fetch_cookbook_authz(OrgId, CookbookName) ->
     end.
 
 %% @doc Delete all checksums for a given cookbook version
--spec delete_checksums(OrgId::binary(),
+-spec delete_cookbook_version_checksums(OrgId::binary(),
                        CookbookVersionId::binary()) -> {ok, 1 } | {error, _}.
-delete_checksums(OrgId, CookbookVersionId) ->
+delete_cookbook_version_checksums(OrgId, CookbookVersionId) ->
     % retrieve a list of checksums before we delete the
     % cookbook_version_checksums record
     Checksums = fetch_cookbook_version_checksums(OrgId, CookbookVersionId),

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -4,6 +4,7 @@
 %% @author Christopher Maier <cm@opscode.com>
 %% @author James Casey <james@opscode.com>
 %% @author Mark Mzyk <mmzyk@opscode.com>
+%% @author Seth Chisamore <schisamo@opscode.com>
 %% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
@@ -890,6 +891,19 @@ delete_sandbox(SandboxId) when is_binary(SandboxId) ->
 
 
 %% Checksum Operations
+
+%% @doc Helper function for testing checksum existence.
+-spec checksum_exists(Checksum :: binary()) ->
+                             boolean() | {error, term()}.
+checksum_exists(ChecksumId) ->
+    case sqerl:select(find_checksum_by_id, [ChecksumId], first_as_scalar, [checksum]) of
+        {ok, Checksum} when is_binary(Checksum) ->
+            true;
+        {ok, none} ->
+            false;
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 %% @doc Given an Org and list of checksums, mark all of them as having been uploaded.  In
 %% practice, this means adding a new row to the checksums table. Returns 'ok' if all are


### PR DESCRIPTION
**NOTE**: This PR is dependent on a FK `ON DELETE` constraint change represented by the following pull-request in `chef-sql-schema`: https://github.com/opscode/chef-sql-schema/pull/5

Properly cleaning up redundant checksums requires 2 distintive steps of related work:
### 1. Delete Redundant Checksums in Database
- **chef_sql:delete_cookbook_version/1 now cleans up checksums** - Attempt to delete all checksum records associated with a particular cookbook version relying on the fact the RDBMS will throw a foreign key constraint error _if_ the checksum record is still needed. YesSQL!
- **chef_db/delete_cookbook_version/2 should expose same contract** - This function needs to return the same values, namely the 1 or 2 indicating whether the enclosing cookbook was deleted.  This flag is needed for proper authz cleanup.
### 2. Delete Checksum Data in S3

This logic has been implemented in `chef_objects` and is represented in this pull-request:
https://github.com/opscode/chef_objects/pull/6
