### PR TITLE
update chef_db:bulk_get/4 with recent schema changes for clients

### DIFF
--- a/itest/itest.erl
+++ b/itest/itest.erl
@@ -1116,9 +1116,7 @@ bulk_fetch_client_data() ->
   Clients =  [ make_client(<<"client_bulk", Num/binary>>) || Num <- [ <<"0">>, <<"1">>, <<"2">> ] ],
   [ ?assertEqual({ok, 1}, chef_sql:create_client(C)) || C <- Clients ],
   Ids = [ C#chef_client.id || C <- Clients ],
-  Expected = [ [{<<"name">>, C#chef_client.name},
-                {<<"clientname">>, C#chef_client.name},
-                {<<"public_key">>, C#chef_client.public_key}] || C <- Clients],
+  Expected = Clients,
 
   {ok, Got} = chef_sql:bulk_get_clients(Ids),
   ?assertEqual(length(Got), 3),

--- a/priv/mysql_statements.config
+++ b/priv/mysql_statements.config
@@ -209,15 +209,25 @@
 %% and you won't know which ids were not found without parsing and
 %% inspecting what did come back.
 {bulk_get_clients_1,
- <<"SELECT name, name AS clientname, public_key FROM clients WHERE id IN (?)">>}.
+ <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
+   "    last_updated_by, created_at, updated_at"
+   "  FROM clients WHERE id IN (?)">>}.
 {bulk_get_clients_2,
- <<"SELECT name, name AS clientname, public_key FROM clients WHERE id IN (?,?)">>}.
+ <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
+   "    last_updated_by, created_at, updated_at"
+   "  FROM clients WHERE id IN (?,?)">>}.
 {bulk_get_clients_3,
- <<"SELECT name, name AS clientname, public_key FROM clients WHERE id IN (?,?,?)">>}.
+ <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
+   "    last_updated_by, created_at, updated_at"
+   "  FROM clients WHERE id IN (?,?,?)">>}.
 {bulk_get_clients_4,
- <<"SELECT name, name AS clientname, public_key FROM clients WHERE id IN (?,?,?,?)">>}.
+ <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
+   "    last_updated_by, created_at, updated_at"
+   "  FROM clients WHERE id IN (?,?,?,?)">>}.
 {bulk_get_clients_5,
- <<"SELECT name, name AS clientname, public_key FROM clients WHERE id IN (?,?,?,?,?)">>}.
+ <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
+   "    last_updated_by, created_at, updated_at"
+   "  FROM clients WHERE id IN (?,?,?,?,?)">>}.
 
 %% cookbook queries
 

--- a/priv/pgsql_statements.config
+++ b/priv/pgsql_statements.config
@@ -207,15 +207,25 @@
 %% and you won't know which ids were not found without parsing and
 %% inspecting what did come back.
 {bulk_get_clients_1,
- <<"SELECT name, name AS clientname, public_key FROM clients WHERE id IN ($1)">>}.
+ <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
+   "    last_updated_by, created_at, updated_at"
+   "  FROM clients WHERE id IN ($1)">>}.
 {bulk_get_clients_2,
- <<"SELECT name, name AS clientname, public_key FROM clients WHERE id IN ($1,$2)">>}.
+ <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
+   "    last_updated_by, created_at, updated_at"
+   "  FROM clients WHERE id IN ($1,$2)">>}.
 {bulk_get_clients_3,
- <<"SELECT name, name AS clientname, public_key FROM clients WHERE id IN ($1,$2,$3)">>}.
+ <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
+   "    last_updated_by, created_at, updated_at"
+   "  FROM clients WHERE id IN ($1,$2,$3)">>}.
 {bulk_get_clients_4,
- <<"SELECT name, name AS clientname, public_key FROM clients WHERE id IN ($1,$2,$3,$4)">>}.
+ <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
+   "    last_updated_by, created_at, updated_at"
+   "  FROM clients WHERE id IN ($1,$2,$3,$4)">>}.
 {bulk_get_clients_5,
- <<"SELECT name, name AS clientname, public_key FROM clients WHERE id IN ($1,$2,$3,$4,$5)">>}.
+ <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
+   "    last_updated_by, created_at, updated_at"
+   "  FROM clients WHERE id IN ($1,$2,$3,$4,$5)">>}.
 
 %% cookbook queries
 {find_cookbook_by_orgid_name,

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -891,7 +891,8 @@ bulk_get(#context{reqid = ReqId}=Ctx, OrgName, client, Ids) ->
         true ->
             bulk_get_couchdb(Ctx, OrgName, client, Ids);
         false ->
-            bulk_get_result(?SH_TIME(ReqId, chef_sql, bulk_get_clients, (Ids)))
+            ClientRecords = bulk_get_result(?SH_TIME(ReqId, chef_sql, bulk_get_clients, (Ids))),
+            [chef_client:assemble_client_ejson(C, OrgName) || #chef_client{}=C <- ClientRecords]
     end;
 bulk_get(Ctx, OrgName, Type, Ids) ->
     bulk_get_couchdb(Ctx, OrgName, Type, Ids).

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -367,11 +367,11 @@ fetch_clients(OrgId) ->
 %% so we need to construct a binary JSON representation of the table
 %% for serving up in search results.
 %%
-%% Note this return a list of proplists, different from the other bulk_get_X
+%% Note this return a list of chef_client records, different from the other bulk_get_X
 %% calls
 bulk_get_clients(Ids) ->
     Query = bulk_get_query_for_count(client, length(Ids)),
-    case sqerl:select(Query, Ids) of
+    case sqerl:select(Query, Ids, ?ALL(chef_client)) of
         {ok, none} ->
             {ok, not_found};
         {ok, L} when is_list(L) ->


### PR DESCRIPTION
Since client records do not have a 'serialized_object' column we need to 
transform the chef_client records returned by our bulk get into a list 
of ejson representations.

^^ @sf @cm plz to be reviewing so we can get this fix in.

I've integration tested the fix and things look good:

``` shell
root@open-source-chef:/srv/piab/users/applejack# knife search client name:admin
1 items found

admin:       true
chef_type:   client
json_class:  Chef::ApiClient
name:        admin
public_key:  -----BEGIN PUBLIC KEY-----
             MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3OVtTWSHSjEcrbbGzOkw
             kymesA6HCRy766iTpPJ9+KoZMd23ws86q6NzuqQt65arowwCeiBZZeJt+ohsduJb
             kLVlFhjsdNOMp61IAT9omxmgkD8v/q2x2fNST1YxJUFZn9zOerFpMsdc+hUSH4sY
             vGjtmJEvHIvjsB71AHvmcYZovazuLtjmFrPbzXKx7Zvhx8smjdZ8yCk5T5C0VXPX
             JTyfuM1C9pG2l5hwqjJPtRgejdRjVLAueleUtPqYxiQJpY3k+FRYD1jwkSfeaG+5
             9JmMynd4NqdV/MerWXq5QRM3FtGNamBMtsPa5ZpVqNH7Aco6dNPsmGO7NY9CunXp
             WQIDAQAB
             -----END PUBLIC KEY-----
```
