### PR TITLE
Replace update_fun with update

### DIFF
--- a/test/chef_db_tests.erl
+++ b/test/chef_db_tests.erl
@@ -190,16 +190,6 @@ fetch_cookbook_versions_test_() ->
      ]
     }.
 
-update_fun_test_() ->
-    [
-     ?_assertEqual(update_data_bag_item, chef_db:update_fun(#chef_data_bag_item{})),
-     ?_assertEqual(update_environment, chef_db:update_fun(#chef_environment{})),
-     ?_assertEqual(update_node, chef_db:update_fun(#chef_node{})),
-     ?_assertEqual(update_role, chef_db:update_fun(#chef_role{})),
-     ?_assertEqual(update_cookbook_version,
-                   chef_db:update_fun(#chef_cookbook_version{}))
-    ].
-
 set_app_env() ->
     test_utils:start_stats_hero(),
     application:set_env(chef_db, couchdb_host, "localhost"),


### PR DESCRIPTION
@seth This is the pull request from an initial modest cleanup
@cm or anyone else - feel free to review.

This change eliminates a level of missdirection;
Uses the passed in record to determine what
argument should be supplied to update_object,
instead of using a seperate function
