### PR TITLE
[OC-4523] cleanup checksums on a cookbook version update

### DIFF
--- a/include/chef_db.hrl
+++ b/include/chef_db.hrl
@@ -19,3 +19,8 @@
           'cookbook_delete' :: boolean(),
           'deleted_checksums' :: [ Checksum::binary()]
          }).
+
+-record(chef_db_cb_version_update, {
+          'deleted_checksums' :: [ Checksum::binary()],
+          'added_checksums' :: [ Checksum::binary()]
+         }).


### PR DESCRIPTION
- update chef_sql:update_cookbook_version/1 to return #chef_db_cb_version_update{} 
  record which contains checksum additions and deletions (which are already 
  computed in chef_sql:update_cookbook_version_checksums/1).
- chef_db:update/3 now properly cleans up deleted checksums via 
  chef_s3:delete_checksums/2 based on return values from 
  chef_sql:update_cookbook_version/1

@seth itests pass and code has been run through dialyzer.  I plan on loading code into a dev-vm tomorrow and writing some pedant tests to verify checksums are fully being deleted from bookshelf on cookbook update.
