### PR TITLE
OC-5440 Index for cookbook_version_id in cookbook checksums

### DIFF
--- a/itest/itest.erl
+++ b/itest/itest.erl
@@ -1511,7 +1511,10 @@ fetch_cookbook_version_checksums() ->
                                            {CookbookVersion#chef_cookbook_version.major,
                                             CookbookVersion#chef_cookbook_version.minor,
                                             CookbookVersion#chef_cookbook_version.patch}}),
-    ?assertEqual(CookbookVersion, Got).
+    % We don't know the order the checksums will come back as
+    NormalizedGotChecksums = lists:sort(Got#chef_cookbook_version.checksums),
+    NormalizedGot = Got#chef_cookbook_version{checksums = NormalizedGotChecksums},
+    ?assertEqual(CookbookVersion, NormalizedGot).
 
 fetch_cookbook_version_different_version() ->
     Cookbook = make_cookbook(<<"fetch_different">>),

--- a/priv/mysql_schema.sql
+++ b/priv/mysql_schema.sql
@@ -61,6 +61,7 @@ CREATE TABLE `cookbook_version_checksums` (
   CONSTRAINT `cookbook_version_checksums_org_id_fkey` FOREIGN KEY (`org_id`, `checksum`) REFERENCES `checksums` (`org_id`, `checksum`) ON UPDATE CASCADE,
   CONSTRAINT `cookbook_version_checksums_ibfk_1` FOREIGN KEY (`cookbook_version_id`) REFERENCES `cookbook_versions` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+CREATE INDEX cookbook_version_checksums_by_id ON cookbook_version_checksums(cookbook_version_id);
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `cookbook_version_dependencies`;
 /*!50001 DROP VIEW IF EXISTS `cookbook_version_dependencies`*/;

--- a/priv/pgsql_schema.sql
+++ b/priv/pgsql_schema.sql
@@ -101,6 +101,7 @@ ALTER TABLE ONLY cookbook_versions ALTER COLUMN meta_long_desc SET STORAGE EXTER
 ALTER TABLE ONLY cookbook_versions ALTER COLUMN metadata SET STORAGE EXTERNAL;
 ALTER TABLE ONLY cookbook_versions ALTER COLUMN serialized_object SET STORAGE EXTERNAL;
 
+CREATE INDEX cookbook_version_checksums_by_id ON cookbook_version_checksums(cookbook_version_id);
 
 --
 -- Name: cookbooks; Type: TABLE; Schema: public; Owner: -; Tablespace: 


### PR DESCRIPTION
- Added index to Postgres schema
- Added index to MySQL schema
- Updated checksum itest

Tested:
- Postgres (itest, pedant)
- Mysql (itest)

I have _not_ tested under Mysql with Pedant. I am pushing this up so people can review it while I figure out how to get dev-vm working with mysql.
