### PR TITLE
Add metric instrumentation for fetch_client call in chef_db

### DIFF
--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -246,12 +246,13 @@ fetch_org_id(#context{reqid = ReqId,
 %%%
 fetch_couchdb_client(#context{} = _Context, not_found, _ClientName) ->
     not_found;
-fetch_couchdb_client(#context{otto_connection = Server} = Context, OrgName, ClientName) ->
+fetch_couchdb_client(#context{reqid = ReqId, otto_connection = Server} = Context,
+                     OrgName, ClientName) ->
     case fetch_org_id(Context, OrgName) of
         not_found ->
             not_found;
         OrgId ->
-            case chef_otto:fetch_client(Server, OrgId, ClientName) of
+            case ?SH_TIME(ReqId, chef_otto, fetch_client, (Server, OrgId, ClientName)) of
                 {not_found, _} -> not_found;
                 Other -> Other
             end

--- a/test/chef_db_tests.erl
+++ b/test/chef_db_tests.erl
@@ -161,6 +161,8 @@ fetch_requestor_test_() ->
                ?assertEqual(Got, Client),
                Stats = stats_hero:snapshot(<<"req-id-123">>, all),
                ExpectKeys = [<<"req_time">>,
+                             <<"rdbms.chef_otto.fetch_client_time">>,
+                             <<"rdbms.chef_otto.fetch_client_count">>,
                              <<"rdbms.chef_otto.fetch_org_id_time">>,
                              <<"rdbms.chef_otto.fetch_org_id_count">>,
                              <<"rdbms_time">>,

--- a/test/chef_db_tests.erl
+++ b/test/chef_db_tests.erl
@@ -66,14 +66,16 @@ fetch_requestor_test_() ->
                ExpectKeys = [<<"req_time">>,
                              <<"rdbms.chef_sql.fetch_client_time">>,
                              <<"rdbms.chef_sql.fetch_client_count">>,
-                             <<"rdbms.chef_otto.fetch_org_id_time">>,
-                             <<"rdbms.chef_otto.fetch_org_id_count">>,
+                             <<"couchdb.chef_otto.fetch_org_id_time">>,
+                             <<"couchdb.chef_otto.fetch_org_id_count">>,
                              <<"rdbms.chef_sql.fetch_user_time">>,
                              <<"rdbms.chef_sql.fetch_user_count">>,
+                             <<"couchdb_count">>,
+                             <<"couchdb_time">>,
                              <<"rdbms_time">>,
                              <<"rdbms_count">>],
                GotKeys = [ Key || {Key, _} <- Stats ],
-               ?assertEqual(ExpectKeys, GotKeys)
+               ?assertEqual(lists:sort(ExpectKeys), lists:sort(GotKeys))
        end
       },
       {"a client is found SQL cert",
@@ -130,12 +132,14 @@ fetch_requestor_test_() ->
                ExpectKeys = [<<"req_time">>,
                              <<"rdbms.chef_sql.fetch_client_time">>,
                              <<"rdbms.chef_sql.fetch_client_count">>,
-                             <<"rdbms.chef_otto.fetch_org_id_time">>,
-                             <<"rdbms.chef_otto.fetch_org_id_count">>,
+                             <<"couchdb.chef_otto.fetch_org_id_time">>,
+                             <<"couchdb.chef_otto.fetch_org_id_count">>,
+                             <<"couchdb_count">>,
+                             <<"couchdb_time">>,
                              <<"rdbms_time">>,
                              <<"rdbms_count">>],
                GotKeys = [ Key || {Key, _} <- Stats ],
-               ?assertEqual(ExpectKeys, GotKeys)
+               ?assertEqual(lists:sort(ExpectKeys), lists:sort(GotKeys))
        end
       },
       {"a client is found Couchdb",
@@ -161,14 +165,14 @@ fetch_requestor_test_() ->
                ?assertEqual(Got, Client),
                Stats = stats_hero:snapshot(<<"req-id-123">>, all),
                ExpectKeys = [<<"req_time">>,
-                             <<"rdbms.chef_otto.fetch_client_time">>,
-                             <<"rdbms.chef_otto.fetch_client_count">>,
-                             <<"rdbms.chef_otto.fetch_org_id_time">>,
-                             <<"rdbms.chef_otto.fetch_org_id_count">>,
-                             <<"rdbms_time">>,
-                             <<"rdbms_count">>],
+                             <<"couchdb.chef_otto.fetch_client_time">>,
+                             <<"couchdb.chef_otto.fetch_client_count">>,
+                             <<"couchdb.chef_otto.fetch_org_id_time">>,
+                             <<"couchdb.chef_otto.fetch_org_id_count">>,
+                             <<"couchdb_count">>,
+                             <<"couchdb_time">>],
                GotKeys = [ Key || {Key, _} <- Stats ],
-               ?assertEqual(ExpectKeys, GotKeys)
+               ?assertEqual(lists:sort(ExpectKeys), lists:sort(GotKeys))
        end
       }
      ]}.
@@ -210,12 +214,14 @@ fetch_cookbook_versions_test_() ->
              ExpectKeys = [<<"req_time">>,
                            <<"rdbms.chef_sql.fetch_cookbook_versions_time">>,
                            <<"rdbms.chef_sql.fetch_cookbook_versions_count">>,
-                           <<"rdbms.chef_otto.fetch_org_id_time">>,
-                           <<"rdbms.chef_otto.fetch_org_id_count">>,
+                           <<"couchdb.chef_otto.fetch_org_id_time">>,
+                           <<"couchdb.chef_otto.fetch_org_id_count">>,
+                           <<"couchdb_count">>,
+                           <<"couchdb_time">>,
                            <<"rdbms_time">>,
                            <<"rdbms_count">>],
              GotKeys = [ Key || {Key, _} <- Stats ],
-             ?assertEqual(ExpectKeys, GotKeys)
+             ?assertEqual(lists:sort(ExpectKeys), lists:sort(GotKeys))
          end},
        {"fetch_cookbook_versions passes structured list",
          fun() ->
@@ -260,4 +266,4 @@ stats_hero_config() ->
      {org_name, "myorg"},
      {request_id, ?REQ_ID},
      {label_fun, {test_utils, stats_hero_label}},
-     {upstream_prefixes, [<<"rdbms">>, <<"solr">>]}].
+     {upstream_prefixes, [<<"rdbms">>, <<"couchdb">>, <<"solr">>]}].

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -90,7 +90,7 @@ validate_modules(Modules) ->
 stats_hero_label({chef_sql, Fun}) ->
     stats_hero_label0(rdbms, {chef_sql, Fun});
 stats_hero_label({chef_otto, Fun}) ->
-    stats_hero_label0(rdbms, {chef_otto, Fun});
+    stats_hero_label0(couchdb, {chef_otto, Fun});
 stats_hero_label({chef_solr, Fun}) ->
     stats_hero_label0(solr, {chef_solr, Fun});
 stats_hero_label({BadPrefix, Fun}) ->


### PR DESCRIPTION
We were missing instrumentation on the legacy couchdb side of the
action. This adds in the instrumentation and updates the tests to
verify that upsreams get reported as we expect.
