### PR TITLE
Integrate new depsolver with semver support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 %% {erl_opts, [debug_info]}.
 
 {deps, [{chef_objects, ".*",
-         {git, "git://github.com/opscode/chef_objects.git", {branch, "master"}}},
+         {git, "git://github.com/opscode/chef_objects.git", {branch, "sf/eric-semver"}}},
 
         {couchbeam, ".*",
          {git, "git://github.com/opscode/couchbeam.git", {branch, "old_api"}}},


### PR DESCRIPTION
This set of PRs integrates an update to depsolver that includes
support for semver versions at the depsolver layer. It does NOT add
support at the chef level, but everything is working with the API
change in depsolver.
