### PR TITLE
Add depsolver as a direct dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,10 @@
             {git, "git://github.com/opscode/stats_hero.git", {branch, "master"}}},
 
         {ej, ".*",
-         {git, "git://github.com/seth/ej.git", {branch, "master"}}}
+         {git, "git://github.com/seth/ej.git", {branch, "master"}}},
+
+        {depsolver, ".*",
+         {git, "git://github.com/opscode/depsolver.git", {branch, "master"}}}
        ]}.
 
 {cover_enabled, true}.


### PR DESCRIPTION
Adding depsolver as a direct dependency. Here's an audit of the usage of the depsolver library within chef_db to show that it uses non of the solving functions:

```
upsilon:chef_db stephen$ ack -a depsolver:
src/chef_db.erl
587:                                              OrgName :: binary()) -> [depsolver:dependency_set()] |

src/chef_sql.erl
624:-spec fetch_all_cookbook_version_dependencies(OrgId :: object_id()) -> {ok, [depsolver:dependency_set()]} |
680:                    {ok, Filtered} = depsolver:filter_packages(Packages, Constraints),
1531:-spec process_dependency_resultset(proplists:proplist()) -> [depsolver:dependency_set()].
1537:                                   WorkingDependencySet :: [depsolver:dependency_set()]) ->
1538:                                          FinalDependencySet :: [depsolver:dependency_set()].
1567:-spec row_to_dependency_set(Row :: proplists:proplist()) -> depsolver:dependency_set().
```
