### PR TITLE
Flexible bulk_get using postgres arrays as WHERE id = ANY($1)

### DIFF
--- a/priv/pgsql_statements.config
+++ b/priv/pgsql_statements.config
@@ -92,16 +92,12 @@
 {list_node_ids_names_for_org,
  <<"SELECT id, name FROM nodes WHERE org_id = $1">>}.
 
-%% bulk_get_nodes_X queries used for fetching nodes returned from
-%% search only returns the gzip JSON data.  If a node has been
+%% bulk_get_nodes query used for fetching nodes returned from
+%% search; only returns the gzip JSON data.  If a node has been
 %% deleted, you may get back fewer than X nodes and you won't know
 %% which ids were not found without parsing and inspecting what did
-%% come back.
-{bulk_get_nodes_1, <<"SELECT serialized_object FROM nodes WHERE id IN ($1)">>}.
-{bulk_get_nodes_2, <<"SELECT serialized_object FROM nodes WHERE id IN ($1,$2)">>}.
-{bulk_get_nodes_3, <<"SELECT serialized_object FROM nodes WHERE id IN ($1,$2,$3)">>}.
-{bulk_get_nodes_4, <<"SELECT serialized_object FROM nodes WHERE id IN ($1,$2,$3,$4)">>}.
-{bulk_get_nodes_5, <<"SELECT serialized_object FROM nodes WHERE id IN ($1,$2,$3,$4,$5)">>}.
+%% come back. Parameter $1 must be an ARRAY of ids.
+{bulk_get_nodes, <<"SELECT serialized_object FROM nodes WHERE id = ANY($1)">>}.
 
 %% role queries
 
@@ -126,16 +122,12 @@
 {list_role_ids_names_for_org,
  <<"SELECT id, name FROM roles WHERE org_id = $1">>}.
 
-%% bulk_get_roles_X queries used for fetching roles returned from
+%% bulk_get_roles query used for fetching roles returned from
 %% search only returns the gzip JSON data.  If a role has been
 %% deleted, you may get back fewer than X roles and you won't know
 %% which ids were not found without parsing and inspecting what did
 %% come back.
-{bulk_get_roles_1, <<"SELECT serialized_object FROM roles WHERE id IN ($1)">>}.
-{bulk_get_roles_2, <<"SELECT serialized_object FROM roles WHERE id IN ($1,$2)">>}.
-{bulk_get_roles_3, <<"SELECT serialized_object FROM roles WHERE id IN ($1,$2,$3)">>}.
-{bulk_get_roles_4, <<"SELECT serialized_object FROM roles WHERE id IN ($1,$2,$3,$4)">>}.
-{bulk_get_roles_5, <<"SELECT serialized_object FROM roles WHERE id IN ($1,$2,$3,$4,$5)">>}.
+{bulk_get_roles, <<"SELECT serialized_object FROM roles WHERE id = ANY($1)">>}.
 
 %% data_bag queries
 
@@ -186,16 +178,12 @@
 {list_data_bag_item_ids_names_for_org,
  <<"SELECT id, item_name FROM data_bag_items WHERE org_id = $1 AND data_bag_name = $2">>}.
 
-%% bulk_get_data_bag_items_X queries used for fetching data_bag_items returned from
-%% search only returns the gzip JSON data.  If a data_bag_item has been
-%% deleted, you may get back fewer than X data_bag_items and you won't know
-%% which ids were not found without parsing and inspecting what did
-%% come back.
-{bulk_get_data_bag_items_1, <<"SELECT serialized_object FROM data_bag_items WHERE id IN ($1)">>}.
-{bulk_get_data_bag_items_2, <<"SELECT serialized_object FROM data_bag_items WHERE id IN ($1,$2)">>}.
-{bulk_get_data_bag_items_3, <<"SELECT serialized_object FROM data_bag_items WHERE id IN ($1,$2,$3)">>}.
-{bulk_get_data_bag_items_4, <<"SELECT serialized_object FROM data_bag_items WHERE id IN ($1,$2,$3,$4)">>}.
-{bulk_get_data_bag_items_5, <<"SELECT serialized_object FROM data_bag_items WHERE id IN ($1,$2,$3,$4,$5)">>}.
+%% bulk_get_data_bag_items query used for fetching data_bag_items
+%% returned from search only returns the gzip JSON data.  If a
+%% data_bag_item has been deleted, you may get back fewer than X
+%% data_bag_items and you won't know which ids were not found without
+%% parsing and inspecting what did come back.
+{bulk_get_data_bag_items, <<"SELECT serialized_object FROM data_bag_items WHERE id = ANY($1)">>}.
 
 %% environment queries
 
@@ -220,16 +208,12 @@
 {list_environment_ids_names_for_org,
  <<"SELECT id, name FROM environments WHERE org_id = $1">>}.
 
-%% bulk_get_environments_X queries used for fetching environments returned from
-%% search only returns the gzip JSON data.  If a environment has been
-%% deleted, you may get back fewer than X environments and you won't know
-%% which ids were not found without parsing and inspecting what did
-%% come back.
-{bulk_get_environments_1, <<"SELECT serialized_object FROM environments WHERE id IN ($1)">>}.
-{bulk_get_environments_2, <<"SELECT serialized_object FROM environments WHERE id IN ($1,$2)">>}.
-{bulk_get_environments_3, <<"SELECT serialized_object FROM environments WHERE id IN ($1,$2,$3)">>}.
-{bulk_get_environments_4, <<"SELECT serialized_object FROM environments WHERE id IN ($1,$2,$3,$4)">>}.
-{bulk_get_environments_5, <<"SELECT serialized_object FROM environments WHERE id IN ($1,$2,$3,$4,$5)">>}.
+%% bulk_get_environments query used for fetching environments returned
+%% from search only returns the gzip JSON data.  If a environment has
+%% been deleted, you may get back fewer than X environments and you
+%% won't know which ids were not found without parsing and inspecting
+%% what did come back.
+{bulk_get_environments, <<"SELECT serialized_object FROM environments WHERE id = ANY($1)">>}.
 
 %% client queries
 
@@ -256,35 +240,19 @@
 {list_client_ids_names_for_org,
  <<"SELECT id, name FROM clients WHERE org_id = $1">>}.
 
-%% bulk_get_clients_X queries used for fetching clients returned from
+%% bulk_get_clients query used for fetching clients returned from
 %% search returns the minimum fields needed to construct a client
-%% search response since there is no serialized object.  Note for compatibility
-%% search on clientname in ruby we return the name twice, once as 'name' and
-%% once as 'clientname'
+%% search response since there is no serialized object.  Note for
+%% compatibility search on clientname in ruby we return the name
+%% twice, once as 'name' and once as 'clientname'
 %%
 %% If a client has been deleted, you may get back fewer than X clients
 %% and you won't know which ids were not found without parsing and
 %% inspecting what did come back.
-{bulk_get_clients_1,
+{bulk_get_clients,
  <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
    "    last_updated_by, created_at, updated_at"
-   "  FROM clients WHERE id IN ($1)">>}.
-{bulk_get_clients_2,
- <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
-   "    last_updated_by, created_at, updated_at"
-   "  FROM clients WHERE id IN ($1,$2)">>}.
-{bulk_get_clients_3,
- <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
-   "    last_updated_by, created_at, updated_at"
-   "  FROM clients WHERE id IN ($1,$2,$3)">>}.
-{bulk_get_clients_4,
- <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
-   "    last_updated_by, created_at, updated_at"
-   "  FROM clients WHERE id IN ($1,$2,$3,$4)">>}.
-{bulk_get_clients_5,
- <<"SELECT id, authz_id, org_id, name, validator, admin, public_key, pubkey_version,"
-   "    last_updated_by, created_at, updated_at"
-   "  FROM clients WHERE id IN ($1,$2,$3,$4,$5)">>}.
+   "  FROM clients WHERE id = ANY($1)">>}.
 
 %% cookbook queries
 {find_cookbook_by_orgid_name,
@@ -394,31 +362,14 @@
 
 %% Used in implementation of environments/ENVIRONMENT/recipes endpoint
 %%
-%% These queries shouldn't use the `cookbook_versions_by_rank' view,
-%% even though the information is present and we wouldn't need the
-%% JOIN clause, because it will compute ranks unnecessarily; we are
-%% just interested in individual cookbook versions here.
-{bulk_get_cbv_serialized_object_1,
+%% This query shouldn't use the `cookbook_versions_by_rank' view, even
+%% though the information is present and we wouldn't need the JOIN
+%% clause, because it will compute ranks unnecessarily; we are just
+%% interested in individual cookbook versions here.
+{bulk_get_cbv_serialized_object,
  <<"SELECT name, serialized_object
     FROM joined_cookbook_version
-    WHERE id IN ($1)">>}.
-{bulk_get_cbv_serialized_object_2,
- <<"SELECT name, serialized_object
-    FROM joined_cookbook_version
-    WHERE id IN ($1, $2)">>}.
-{bulk_get_cbv_serialized_object_3,
- <<"SELECT name, serialized_object
-    FROM joined_cookbook_version
-    WHERE id IN ($1, $2, $3)">>}.
-{bulk_get_cbv_serialized_object_4,
- <<"SELECT name, serialized_object
-    FROM joined_cookbook_version
-    WHERE id IN ($1, $2, $3, $4)">>}.
-{bulk_get_cbv_serialized_object_5,
- <<"SELECT name, serialized_object
-    FROM joined_cookbook_version
-    WHERE id IN ($1, $2, $3, $4, $5)">>}.
-
+    WHERE id = ANY($1)">>}.
 
 {fetch_all_cookbook_version_dependencies_by_orgid,
  <<"SELECT name, major || '.' || minor || '.' || patch AS version, dependencies


### PR DESCRIPTION
Rather than implementing bulk_get queries as hard-coded prepared
queries via IN for 1, 2, 3, 4, or 5 items, we now use a Postgres array
as the query parameter and the ANY() function.

Accoding to this post [1](http://www.postgresql.org/message-id/5373.1158351561@sss.pgh.pa.us), the efficiency of the operation should be
equivalent to the IN approach.
