### PR TITLE
Convert to envy

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,10 @@
          {git, "git://github.com/seth/ej.git", {branch, "master"}}},
 
         {depsolver, ".*",
-         {git, "git://github.com/opscode/depsolver.git", {branch, "master"}}}
+         {git, "git://github.com/opscode/depsolver.git", {branch, "master"}}},
+        
+        {envy, ".*",
+         {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
        ]}.
 
 {cover_enabled, true}.

--- a/src/chef_cache.erl
+++ b/src/chef_cache.erl
@@ -51,12 +51,8 @@
          prune_worker/1]).
 
 init(Name) when is_atom(Name) ->
-    case application:get_env(chef_db, cache_defaults) of
-        undefined ->
-            error(missing_defaults);
-        {ok, Defaults} ->
-            init([{?NAME_OPT, Name}|Defaults])
-    end;
+    init([{?NAME_OPT, Name} | envy:get(chef_db, cache_defaults, list)]);
+
 init(Options) when is_list(Options) ->
     {ok, Config} = build_config(Options),
     Name = proplists:get_value(?NAME_KEY, Config),

--- a/src/chef_otto.erl
+++ b/src/chef_otto.erl
@@ -92,8 +92,8 @@
 
 -spec connect() -> couch_server().
 connect() ->
-    {ok, Host} = application:get_env(chef_db, couchdb_host),
-    {ok, Port} = application:get_env(chef_db, couchdb_port),
+    Host = envy:get(chef_db, couchdb_host, string),
+    Port = envy:get(chef_db, couchdb_port, non_neg_integer),
     connect(Host, Port).
 
 -spec connect(string(), http_port()) -> couch_server().

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -1387,7 +1387,7 @@ extract_ids_using_filtered_results(MappingDict, FilteredCookbookVersions) ->
                                                               SerializedObject :: binary()}]} |
                                                        {error, term()}.
 fetch_cookbook_version_serialized_objects(Ids) ->
-    {ok, BatchSize} = application:get_env(chef_db, bulk_fetch_batch_size),
+    BatchSize = envy:get(chef_db, bulk_fetch_batch_size, pos_integer),
     fetch_cookbook_version_serialized_objects(Ids, BatchSize, []).
 
 %% @doc Recursive implementation of {@link fetch_cookbook_version_serialized_objects/1}.


### PR DESCRIPTION
Application:get_env requires validation of data types.  This logic has been 
duplicated several times.  This attempts to consolidate validation to a single
library, envy.
