### PR TITLE
Unify new behavior based functions and dialyzer fixes

### DIFF
--- a/itest/chef_db_SUITE.erl
+++ b/itest/chef_db_SUITE.erl
@@ -132,6 +132,12 @@ setup_chef_db(Config) ->
                          [{<<"created_at">>, fun sqerl_transformers:convert_YMDHMS_tuple_to_datetime/1},
                         {<<"updated_at">>, fun sqerl_transformers:convert_YMDHMS_tuple_to_datetime/1}]}
                        ]),
+
+    itest_util:set_env(stats_hero,
+                       [{udp_socket_pool_size, 1},
+                        {estatsd_host, "localhost"},
+                        {estatsd_port, 3001}]),
+
     %% In production we use 5, but I'm using 2 here for the time being
     %% to exercise the joining together of multiple database calls.  See the TODO
     %% in the "Environment-filtered Recipes Tests" section for more.
@@ -158,7 +164,7 @@ cleanup_chef_db() ->
     error_logger:tty(true).
 
 app_list() ->
-    [crypto, public_key, ssl, epgsql, pooler].
+    [crypto, public_key, ssl, epgsql, pooler, stats_hero].
 
 ensure_started(App) ->
     case application:start(App) of

--- a/itest/chef_sql_nodes.erl
+++ b/itest/chef_sql_nodes.erl
@@ -13,16 +13,17 @@ make_node(Prefix) ->
     Id = itest_util:make_id(Prefix),
     AzId = itest_util:make_az_id(Prefix),
     Name = <<"node_", Prefix/binary>>,
-    #chef_node{
-                id=Id, authz_id=AzId, org_id=itest_util:the_org_id(), name=Name,
-                environment="_default", last_updated_by="noone", serialized_object= <<"">>,
-                created_at= {datetime,{{2011,10,1},{16,47,46}}}, updated_at= {datetime,{{2011,10,1},{16,47,46}}} }.
+    #chef_node{id=Id, authz_id = AzId,
+               org_id=itest_util:the_org_id(), name=Name,
+               environment="_default", serialized_object= <<"{\"key\":\"fake node\"}">>}.
 
 node_list() ->
-    [ make_node(<<"01">>) ].
+    ActorId = itest_util:make_az_id(<<"node-maker">>),
+    [ {make_node(<<"01">>), ActorId}, {make_node(<<"02">>), ActorId}].
 
 insert_node_data() ->
+    Ctx = chef_db:make_context(<<"itest-nodes">>, stub_xdl, stub_otto),
     Nodes = node_list(),
-    Expected = lists:duplicate(length(Nodes), {ok, 1}),
-    Results = [chef_sql:create_node(Node) || Node <- Nodes ],
+    Expected = lists:duplicate(length(Nodes), ok),
+    Results = [ chef_db:create(Node, Ctx, ActorId) || {Node, ActorId} <- Nodes ],
     ?assertEqual(Expected, Results).

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -166,9 +166,9 @@ create(ObjectRec0, #context{reqid = ReqId}, ActorId) ->
         {error, Why} -> {error, Why}
     end.
 
--spec delete(#context{}, object_rec()) -> {ok, 1 | 2} | not_found | {error, _}.
-delete(#context{reqid = ReqId} = Ctx,
-       #chef_cookbook_version{org_id = OrgId} = CookbookVersion) ->
+-spec delete(object_rec(), #context{}) -> {ok, 1 | 2} | not_found | {error, _}.
+delete(#chef_cookbook_version{org_id = OrgId} = CookbookVersion,
+       #context{reqid = ReqId} = Ctx) ->
     case delete_object(Ctx, delete_cookbook_version, CookbookVersion) of
         #chef_db_cb_version_delete{cookbook_delete=CookbookDeleted, deleted_checksums=DeletedChecksums} ->
             ?SH_TIME(ReqId, chef_s3, delete_checksums, (OrgId, DeletedChecksums)),
@@ -179,7 +179,7 @@ delete(#context{reqid = ReqId} = Ctx,
             end;
         Result -> Result %% not_found or {error, _}
     end;
-delete(#context{reqid = ReqId}, ObjectRec) ->
+delete(ObjectRec, #context{reqid = ReqId}) ->
     QueryName = chef_object:delete_query(ObjectRec),
     Id = chef_object:id(ObjectRec),
     case stats_hero:ctime(ReqId, {chef_sql, delete_object},
@@ -205,8 +205,8 @@ fetch(ObjectRec, #context{reqid = ReqId}) ->
         {error, _Why} = Error -> Error
     end.
 
--spec list(#context{}, object_rec()) -> {ok, [binary()]} | {error, _}.
-list(#context{reqid = ReqId} = _Ctx, StubRec) ->
+-spec list(object_rec(), #context{}) -> {ok, [binary()]} | {error, _}.
+list(StubRec, #context{reqid = ReqId} = _Ctx) ->
     stats_hero:ctime(ReqId, {chef_sql, fetch_object_names},
                       fun() ->
                               chef_sql:fetch_object_names(StubRec)

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -486,7 +486,7 @@ fetch_roles(#context{} = Ctx, OrgName) ->
 fetch_data_bag_item_ids(#context{} = Ctx, OrgName, DataBagName) ->
     fetch_objects(Ctx, fetch_data_bag_item_ids, OrgName, DataBagName).
 
--spec delete(#context{}, tuple()) -> {ok, 1 | 2} | not_found | {error, _}.
+-spec delete(#context{}, object_rec()) -> {ok, 1 | 2} | not_found | {error, _}.
 delete(#context{reqid = ReqId} = Ctx,
        #chef_cookbook_version{org_id = OrgId} = CookbookVersion) ->
     case delete_object(Ctx, delete_cookbook_version, CookbookVersion) of

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -205,7 +205,7 @@ fetch(ObjectRec, #context{reqid = ReqId}) ->
         {error, _Why} = Error -> Error
     end.
 
--spec list(object_rec(), #context{}) -> {ok, [binary()]} | {error, _}.
+-spec list(object_rec(), #context{}) -> [binary()] | {error, _}.
 list(StubRec, #context{reqid = ReqId} = _Ctx) ->
     stats_hero:ctime(ReqId, {chef_sql, fetch_object_names},
                       fun() ->


### PR DESCRIPTION
This PR cleans up the dialyzer specs, unifies the signatures for the new behavior based functions to always put the ObjectRec first, and does a bit of code cleanup.

With these changes, the newly pushed sf/behaviour-refactor branch of chef_wm builds and dialyzes cleanly.

This PR also includes the start of fixes to restore (once more) the itests for chef_db. It seems we need to switch these to actually test chef_db:\* functions now -- or at least do that for the chef_sql functions that have been removed. The nodes test is now working and similar changes to should be applied to fix up the other failing itests.

/cc @hosh @sdelano @oferrigni 

@manderson26 @marcparadise 
