### PR TITLE
Continue to consolidate chef_object api to now include update

### DIFF
--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -215,12 +215,10 @@ update(#chef_cookbook_version{org_id =OrgId} = Record, #context{reqid = ReqId} =
             ok;
         Result -> Result %% {conflict, _} or {error, _}
     end;
-update(ObjectRec0, #context{reqid = ReqId}, ActorId) ->
-    ObjectRec = chef_object:set_updated(ObjectRec0, ActorId),
-    QueryName = chef_object:update_query(ObjectRec),
-    UpdatedFields = chef_object:fields_for_update(ObjectRec),
+update(ObjectRec, #context{reqid = ReqId}, ActorId) ->
     case stats_hero:ctime(ReqId, {chef_sql, do_update},
-                          fun() -> chef_sql:do_update(QueryName, UpdatedFields) end) of
+                          fun() ->
+                                  chef_sql:update(ObjectRec, ActorId) end) of
         #chef_db_cb_version_update{}=CookbookVersionUpdate -> CookbookVersionUpdate;
         {ok, 1} -> ok;
         {ok, not_found} -> not_found;

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -220,8 +220,8 @@ update(ObjectRec, #context{reqid = ReqId}, ActorId) ->
                           fun() ->
                                   chef_sql:update(ObjectRec, ActorId) end) of
         #chef_db_cb_version_update{}=CookbookVersionUpdate -> CookbookVersionUpdate;
-        {ok, 1} -> ok;
-        {ok, not_found} -> not_found;
+        1 -> ok;
+        not_found -> not_found;
         {conflict, Message} -> {conflict, Message};
         {error, Error} -> {error, Error}
     end.

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -39,6 +39,7 @@
          create_object/2,
          delete_object/2,
          do_update/2,
+         update/2,
          fetch_object/4,
          fetch_object_names/1,
          fetch/1,
@@ -968,6 +969,9 @@ flatten_record(Rec) ->
         false -> ok
     end,
     Tail.
+
+update(ObjectRec, ActorId) ->
+    chef_object:update(ObjectRec, ActorId, fun do_update/2).
 
 do_update(QueryName, UpdateFields) ->
     case sqerl:statement(QueryName, UpdateFields) of


### PR DESCRIPTION
chef_object:update is implemented for basic cases across all 
chef_objects.  More complex implemenations are still handled
by chef_db/chef_sql.
