### PR TITLE
Of/oc 9637

### DIFF
--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -158,8 +158,9 @@ create(#chef_cookbook_version{} = Record, DbContext, ActorId) ->
 create(ObjectRec0, #context{reqid = ReqId}, ActorId) ->
     ObjectRec = chef_object:set_created(ObjectRec0, ActorId),
     QueryName = chef_object:create_query(ObjectRec),
+    FlattenedRecord = chef_object:flatten(ObjectRec),
     case stats_hero:ctime(ReqId, {chef_sql, create_object},
-                          fun() -> chef_sql:create_object(QueryName, ObjectRec) end) of
+                          fun() -> chef_sql:create_object(QueryName, FlattenedRecord) end) of
         {ok, 1} -> ok;
         {conflict, Msg}-> {conflict, Msg};
         {error, Why} -> {error, Why}

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -180,13 +180,8 @@ delete(#chef_cookbook_version{org_id = OrgId} = CookbookVersion,
         Result -> Result %% not_found or {error, _}
     end;
 delete(ObjectRec, #context{reqid = ReqId}) ->
-    QueryName = chef_object:delete_query(ObjectRec),
-    Id = chef_object:id(ObjectRec),
-    case stats_hero:ctime(ReqId, {chef_sql, delete_object},
-                     fun() -> chef_sql:delete_object(QueryName, Id) end) of
-        {ok, not_found} -> not_found;
-        Result -> Result
-    end.
+    stats_hero:ctime(ReqId, {chef_sql, delete_object},
+                     fun() -> chef_sql:delete_object(ObjectRec) end).
 
 -spec fetch(object_rec(),
             DbContext :: #context{}) ->

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -37,6 +37,7 @@
          create_name_id_dict/2,
 
          create_object/2,
+         delete_object/1,
          delete_object/2,
          do_update/2,
          update/2,
@@ -926,6 +927,9 @@ unlink_checksums_from_cbv([Checksum|Rest], OrgId, CookbookVersionId) ->
         Error ->
             Error
     end.
+
+delete_object(Rec) ->
+    chef_object:delete(Rec, fun select_rows/1).
 
 -spec delete_object(delete_query(), binary()) -> {ok, 1 | 'not_found'} | sqerl_error().
 delete_object(delete_sandbox_by_id = Query, Id) ->

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -964,11 +964,6 @@ delete_object(delete_cookbook_by_orgid_name = Query, OrgId, Name) ->
             Error
     end.
 
-is_undefined(undefined) ->
-    true;
-is_undefined(_) ->
-    false.
-
 flatten_record(Rec) ->
     chef_object:flatten(Rec).
 

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -970,14 +970,7 @@ is_undefined(_) ->
     false.
 
 flatten_record(Rec) ->
-    [_RecName|Tail] = tuple_to_list(Rec),
-    %% We detect if any of the fields in the record have not been set
-    %% and throw an error
-    case lists:any(fun is_undefined/1, Tail) of
-        true -> error({undefined_in_record, Rec});
-        false -> ok
-    end,
-    Tail.
+    chef_object:flatten(Rec).
 
 update(ObjectRec, ActorId) ->
     chef_object:update(ObjectRec, ActorId, fun select_rows/1).


### PR DESCRIPTION
Previously, it was assumed that every field in a chef_object record was present in the database.  By allowing elective implementation of flatten_record in the chef_object, chef_objects may now choose to hold fields not backed by postgres.  This allows more types of data to be carried in chef_object records.

Additionally, use the delete_object chef_object api in chef_db/chef_sql.

Lever chef_object:flatten from https://github.com/opscode/chef_objects/pull/58
