### PR TITLE
Move chefp to chef_db

### DIFF
--- a/src/chefp.erl
+++ b/src/chefp.erl
@@ -1,0 +1,55 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% Copyright 2013 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+
+%% @doc `chefp' is a functional programming helpers module
+-module(chefp).
+
+-export([
+         batch_fold/4
+        ]).
+
+%% @doc Generic batch processing as a foldl. Breaks `List' into
+%% batches of size `Size' and calls `Fun(Batch, Acc)' on each batch.
+-spec batch_fold(fun((T, Acc) -> Acc), List, Acc, Size) -> Acc when
+      T :: any(),
+      List :: [T],
+      Acc :: any(),
+      Size :: non_neg_integer().
+batch_fold(_Fun, [], Acc, _Size) ->
+    Acc;
+batch_fold(Fun, List, Acc, Size) when is_list(List) ->
+    batch_fold0(Fun, safe_split(Size, List), Acc, Size).
+
+-spec batch_fold0(fun((T, Acc) -> Acc), {Batch, Rest}, Acc, Size) -> Acc when
+      T :: any(),
+      Batch :: [T],
+      Rest :: [T],
+      Acc :: any(),
+      Size :: non_neg_integer().
+batch_fold0(Fun, {LastBatch, []}, Acc, _Size) ->
+    Fun(LastBatch, Acc);
+batch_fold0(Fun, {Batch, Rest}, Acc, Size) ->
+    batch_fold0(Fun, safe_split(Size, Rest), Fun(Batch, Acc), Size).
+
+safe_split(N, L) ->
+    try
+        lists:split(N, L)
+    catch
+        error:badarg ->
+            {L, []}
+    end.

--- a/test/chefp_tests.erl
+++ b/test/chefp_tests.erl
@@ -1,0 +1,41 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% Copyright 2013 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(chefp_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+batch_fold_test_() ->
+    E = fun(X, Acc) -> [X | Acc] end,
+    [
+     {"Acc returned for empty list",
+      ?_assertEqual(acc, chefp:batch_fold(E, [], acc, 2))},
+
+     {"batch size of N", generator,
+      fun() ->
+              List = [1, 2 , 3],
+              %%       {Size, Expected}
+              Tests = [{1,    [[3], [2], [1]]},
+                       {2,    [[3], [1, 2]]},
+                       {3,    [[1, 2, 3]]},
+                       {4,    [[1, 2, 3]]}],
+              [ ?_assertEqual(Expected, chefp:batch_fold(E, List, [], N))
+                || {N, Expected} <- Tests ]
+      end}
+    ].


### PR DESCRIPTION
This moves chefp to a common spot for usage in reindexing.  Once we have more than a single utility module like this, we can open up a new repo.
