### PR TITLE
initial pass: users endpoint in oc_erchef

### DIFF
--- a/priv/pgsql_statements.config
+++ b/priv/pgsql_statements.config
@@ -25,22 +25,21 @@
 %% id is a guid - for OSC it is currently the couchid - will need to generate it in code
 %% authz_id - will need to generate fake authz_id to meet requirements and fill that in
 %% email can be null
-%% pubkey_version is currently not used by osc users, so set to 1 as default, indicating a CERT
 %% public_key can be null, but it might be best to generate a user a key and put it in here
-%% serialized object is where the password and salt are stored
+%% serialized object is where additional user data is stored.
 %% last_updated_by, created_at, and updated_at are requied
 %% external_authentication_uid is optional, but is where the open_id will be stored.
 %% recovery_authentication_enable is optional and not used
 %% admin is required and used by osc user, set to false by default by the db
 {insert_user,
   <<"INSERT INTO osc_users (id, authz_id, username, email, public_key,
-      hashed_password, salt, hash_type, last_updated_by, created_at,
-      updated_at, external_authentication_uid,
+      pubkey_version, hashed_password, salt, hash_type, last_updated_by,
+      created_at, updated_at, external_authentication_uid,
       recovery_authentication_enabled, admin) VALUES
       ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)">>}.
 
 {find_user_by_username,
-  <<"SELECT id, authz_id, username, email, public_key,
+  <<"SELECT id, authz_id, username, email, public_key, pubkey_version
       hashed_password, salt, hash_type, last_updated_by, created_at,
       updated_at, external_authentication_uid,
       recovery_authentication_enabled, admin
@@ -59,12 +58,13 @@
 <<"UPDATE osc_users
      SET admin = $1,
          public_key = $2,
-         hashed_password = $3,
-         salt = $4,
-         hash_type = $5,
-         last_updated_by = $6,
-         updated_at = $7"
-  "  WHERE id = $8">>
+         pubkey_version = $3,
+         hashed_password = $4,
+         salt = $5,
+         hash_type = $6,
+         last_updated_by = $7,
+         updated_at = $8"
+  "  WHERE id = $9">>
 }.
 
 %% node queries

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -276,16 +276,18 @@ client_record_to_authz_id(_Context, ClientRecord) ->
                       binary()) -> #chef_client{} | #chef_user{} |
                                    %% TODO: fix chef_wm so we can just return 'not_found'
                                    {'not_found', 'client'}.
-fetch_requestor(Context, OrgId, ClientName) ->
-    case fetch(#chef_client{org_id = OrgId, name = ClientName}, Context) of
-        not_found ->
-            case fetch(#chef_user{username = ClientName}, Context) of
+fetch_requestor(Context, undefined, UserName) ->
+            case fetch(#chef_user{username = UserName}, Context) of
                 not_found ->
                     %% back compat for now until we update chef_wm
                     {not_found, client};
                 #chef_user{} = User ->
                     User
             end;
+fetch_requestor(Context, OrgId, ClientName) ->
+    case fetch(#chef_client{org_id = OrgId, name = ClientName}, Context) of
+        not_found ->
+            fetch_requestor(Context, undefined, ClientName);
         #chef_client{} = Client ->
             Client
     end.


### PR DESCRIPTION
- includes users endpoint support in erchef
- support in underyling components for oc_chef_wm requests
  that do not have a valid org, without stubbing out org.
- make oc_erchef aware of global containers in couch
- nginx routing for endpoints

/ping @opscode/server-team

Note that I'm leaning towards maintaining this as a feature branch
pending completion of other works in progress.
