### PR TITLE
Add chef_db:bulk_fetch_cookbook_versions for use in chef_wm_depsolver

### DIFF
--- a/priv/pgsql_statements.config
+++ b/priv/pgsql_statements.config
@@ -363,6 +363,26 @@
     FROM joined_cookbook_version
     WHERE org_id = $1">>}.
 
+%% Used in implementation of environemnts/ENVNAME/cookbook_versions endpoint.
+%%
+%% Depends on the cbv type existing in the schema
+{bulk_fetch_cookbook_versions,
+ <<"WITH inputs AS ( select * from unnest($2::cbv[]) )
+  SELECT v.id,  v.major, v.minor, v.patch, v.frozen, v.meta_attributes,
+         v.meta_deps, v.meta_long_desc, v.metadata, v.serialized_object,
+         v.last_updated_by, v.created_at, v.updated_at, c.authz_id, c.org_id, c.name,
+         (SELECT ARRAY(SELECT checksum FROM cookbook_version_checksums cvc
+                       WHERE org_id = $1 AND cvc.cookbook_version_id = v.id)) checksums
+    FROM inputs,
+         cookbooks as c,
+         cookbook_versions as v
+   WHERE c.org_id = $1
+     AND inputs.name = c.name
+     AND v.cookbook_id = c.id
+     AND v.major = inputs.major
+     AND v.minor = inputs.minor
+     AND v.patch = inputs.patch">>}.
+
 %% Used in implementation of environments/ENVIRONMENT/recipes endpoint
 %%
 %% This query shouldn't use the `cookbook_versions_by_rank' view, even

--- a/src/chef_db.erl
+++ b/src/chef_db.erl
@@ -67,6 +67,7 @@
          fetch_cookbook_version/3,
          fetch_cookbook_versions/2,
          fetch_cookbook_versions/3,
+         bulk_fetch_cookbook_versions/3,
          fetch_latest_cookbook_version/3,
          fetch_latest_cookbook_versions/2,
          fetch_latest_cookbook_versions/3,
@@ -380,6 +381,24 @@ fetch_cookbook_versions(#context{} = Ctx, OrgName) ->
 %% @doc Return a list of all cookbook names and versions in an org
 fetch_cookbook_versions(#context{} = Ctx, OrgName, CookbookName) ->
     fetch_objects(Ctx, fetch_cookbook_versions, OrgName, CookbookName).
+
+%% @doc Given a list of cookbook names and versions, return a list of #chef_cookbook_version
+%% objects.  This is used by the depsolver endpoint.
+-spec bulk_fetch_cookbook_versions(DbContext :: #context{}, OrgName :: binary(), [versioned_cookbook()]) -> [#chef_cookbook_version{}] | {error, any()}.
+bulk_fetch_cookbook_versions(#context{reqid = ReqID} = Ctx, OrgName, []) ->
+    %% Avoid database calls in the case of an empty run_list
+    [];
+bulk_fetch_cookbook_versions(#context{reqid = ReqID} = Ctx, OrgName, VersionedCookbooks) ->
+    case fetch_org_id(Ctx, OrgName) of
+        not_found ->
+            not_found;
+        OrgId ->
+            stats_hero:ctime(ReqID, {chef_sql, bulk_fetch_cookbook_versions},
+                             fun() ->
+                                     chef_sql:bulk_fetch_cookbook_versions(OrgId,
+                                                                           VersionedCookbooks)
+                             end)
+    end.
 
 -spec fetch_cookbook_version(DbContext :: #context{},
                              OrgName :: binary(),

--- a/src/chef_sql.erl
+++ b/src/chef_sql.erl
@@ -584,13 +584,11 @@ cookbook_versions_array_to_binary([], Acc, EndBin, _Sep) ->
 %%
 %%
 -spec cookbook_version_to_binary(versioned_cookbook()) -> binary().
-cookbook_version_to_binary(CkbVer) ->
-    Name = element(1, CkbVer),
-    Version = element(2, CkbVer),
-    Major = list_to_binary(integer_to_list(element(1, Version))),
-    Minor = list_to_binary(integer_to_list(element(2, Version))),
-    Patch = list_to_binary(integer_to_list(element(3, Version))),
-    <<"\"(", Name/binary, ",", Major/binary, ",", Minor/binary, ",", Patch/binary, ")\"">>.
+cookbook_version_to_binary({Name, {MajorInt, MinorInt, PatchInt}}) ->
+    iolist_to_binary([<<"\"(">>, Name, <<",">>,
+                      integer_to_binary(MajorInt), <<",">>,
+                      integer_to_binary(MinorInt), <<",">>,
+                      integer_to_binary(PatchInt), <<")\"">>]).
 
 %% cookbook version ops
 -spec fetch_cookbook_version(OrgId::object_id(),


### PR DESCRIPTION
Currently we make 3 SQL queries per cookbook returned by depsolver.
chef_db:bulk_fetch_cookbook_version allows us to get the same data via
2 total queries, regardless of the number of cookbooks returned by
depsolver.

The hope is that this will substantially reduce the stress that the
cookbook_versions endpoint places on the database.
